### PR TITLE
Add Hotspot Game link to homepage navigation

### DIFF
--- a/index.html
+++ b/index.html
@@ -40,6 +40,7 @@
         <li class="nav-item"><a href="france.html" class="nav-link">French Libraries</a></li>
         <li class="nav-item"><a href="canada.html" class="nav-link">Canadian Libraries</a></li>
         <li class="nav-item"><a href="bookclubs.html" class="nav-link">Book Clubs</a></li>
+        <li class="nav-item"><a href="https://hotspotgame.online/" class="nav-link" target="_blank" rel="noopener noreferrer">热点游戏</a></li>
         <li class="nav-item"><a href="#contact" class="nav-link">Contact Us</a></li>
       </ul>
     </div>


### PR DESCRIPTION
## Summary
- add a Hotspot Game item to the homepage navigation menu that opens the external site in a new tab

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e0c2cb777c83219b43ce972de50721